### PR TITLE
fix animation sub menu items

### DIFF
--- a/2-sw-page-turn-animation.lua
+++ b/2-sw-page-turn-animation.lua
@@ -1,11 +1,11 @@
 --[[--
 Software-based page turn "erase/wipe" animation for e-ink devices.
 
-A new submenu "Page turn animation (patch)" appears under:
+Adds a "Number of steps" option (free spinner, 2 to 24) under:
 Settings (gear) -> Gestures & Actions -> Page turning
-with two options:
-  - Enable animation (mirrors the native toggle)
-  - Number of steps (free spinner, 2 to 24)
+
+Enable/disable of the animation uses the native "swipe_animations"
+toggle; this patch does not duplicate it.
 --]] --
 
 local Device = require("device")
@@ -234,45 +234,31 @@ ReaderMenu.init = function(self)
         addToMainMenu = function(this, menu_items)
             if menu_items.page_turns and menu_items.page_turns.sub_item_table then
                 table.insert(menu_items.page_turns.sub_item_table, {
-                    text = _("Software page turn animation"),
-                    sub_item_table = {
-                        {
-                            text = _("Enable animation"),
-                            checked_func = function()
-                                return G_reader_settings:isTrue("swipe_animations")
-                            end,
-                            callback = function()
-                                G_reader_settings:flipNilOrFalse("swipe_animations")
-                            end,
-                        },
-                        {
-                            keep_menu_open = true,
-                            text_func = function()
-                                local T = require("ffi/util").template
-                                return T(_("Number of steps: %1"), getSteps())
-                            end,
-                            callback = function(touchmenu_instance)
-                                local SpinWidget = require("ui/widget/spinwidget")
-                                UIManager:show(SpinWidget:new {
-                                    title_text = _("Animation steps"),
-                                    info_text = _([[
+                    keep_menu_open = true,
+                    text_func = function()
+                        local T = require("ffi/util").template
+                        return T(_("Number of steps: %1"), getSteps())
+                    end,
+                    callback = function(touchmenu_instance)
+                        local SpinWidget = require("ui/widget/spinwidget")
+                        UIManager:show(SpinWidget:new {
+                            title_text = _("Animation steps"),
+                            info_text = _([[
 How many frames the page-turn wipe animation is split into.
 More steps = smoother animation but slower.
 Fewer steps = faster but choppier.]]),
-                                    value = getSteps(),
-                                    value_min = 2,
-                                    value_max = 24,
-                                    value_step = 1,
-                                    default_value = DEFAULT_STEPS,
-                                    precision = "%d",
-                                    callback = function(spin)
-                                        G_reader_settings:saveSetting(SETTING_KEY, spin.value)
-                                        if touchmenu_instance then touchmenu_instance:updateItems() end
-                                    end,
-                                })
+                            value = getSteps(),
+                            value_min = 2,
+                            value_max = 24,
+                            value_step = 1,
+                            default_value = DEFAULT_STEPS,
+                            precision = "%d",
+                            callback = function(spin)
+                                G_reader_settings:saveSetting(SETTING_KEY, spin.value)
+                                if touchmenu_instance then touchmenu_instance:updateItems() end
                             end,
-                        },
-                    },
+                        })
+                    end,
                 })
             end
         end,

--- a/2-sw-page-turn-animation.lua
+++ b/2-sw-page-turn-animation.lua
@@ -225,46 +225,56 @@ function ReaderPaging:_gotoPage(number, orig_mode)
 end
 
 -- Add a config menu entry under Settings -> Page turning
-local PageTurns = require("ui/elements/page_turns")
+local ReaderMenu = require("apps/reader/modules/readermenu")
+local orig_ReaderMenu_init = ReaderMenu.init
 
-table.insert(PageTurns.sub_item_table, {
-    text = _("Software page turn animation"),
-    sub_item_table = {
-        {
-            text = _("Enable animation"),
-            checked_func = function()
-                return G_reader_settings:isTrue("swipe_animations")
-            end,
-            callback = function()
-                G_reader_settings:flipNilOrFalse("swipe_animations")
-            end,
-        },
-        {
-            keep_menu_open = true,
-            text_func = function()
-                local T = require("ffi/util").template
-                return T(_("Number of steps: %1"), getSteps())
-            end,
-            callback = function(touchmenu_instance)
-                local SpinWidget = require("ui/widget/spinwidget")
-                UIManager:show(SpinWidget:new {
-                    title_text = _("Animation steps"),
-                    info_text = _([[
+ReaderMenu.init = function(self)
+    orig_ReaderMenu_init(self)
+    self:registerToMainMenu({
+        addToMainMenu = function(this, menu_items)
+            if menu_items.page_turns and menu_items.page_turns.sub_item_table then
+                table.insert(menu_items.page_turns.sub_item_table, {
+                    text = _("Software page turn animation"),
+                    sub_item_table = {
+                        {
+                            text = _("Enable animation"),
+                            checked_func = function()
+                                return G_reader_settings:isTrue("swipe_animations")
+                            end,
+                            callback = function()
+                                G_reader_settings:flipNilOrFalse("swipe_animations")
+                            end,
+                        },
+                        {
+                            keep_menu_open = true,
+                            text_func = function()
+                                local T = require("ffi/util").template
+                                return T(_("Number of steps: %1"), getSteps())
+                            end,
+                            callback = function(touchmenu_instance)
+                                local SpinWidget = require("ui/widget/spinwidget")
+                                UIManager:show(SpinWidget:new {
+                                    title_text = _("Animation steps"),
+                                    info_text = _([[
 How many frames the page-turn wipe animation is split into.
 More steps = smoother animation but slower.
 Fewer steps = faster but choppier.]]),
-                    value = getSteps(),
-                    value_min = 2,
-                    value_max = 24,
-                    value_step = 1,
-                    default_value = DEFAULT_STEPS,
-                    precision = "%d",
-                    callback = function(spin)
-                        G_reader_settings:saveSetting(SETTING_KEY, spin.value)
-                        if touchmenu_instance then touchmenu_instance:updateItems() end
-                    end,
+                                    value = getSteps(),
+                                    value_min = 2,
+                                    value_max = 24,
+                                    value_step = 1,
+                                    default_value = DEFAULT_STEPS,
+                                    precision = "%d",
+                                    callback = function(spin)
+                                        G_reader_settings:saveSetting(SETTING_KEY, spin.value)
+                                        if touchmenu_instance then touchmenu_instance:updateItems() end
+                                    end,
+                                })
+                            end,
+                        },
+                    },
                 })
-            end,
-        },
-    },
-})
+            end
+        end,
+    })
+end


### PR DESCRIPTION
The patch `2-sw-page-turn-animation.lua` designed a menu to change the steps but never shows.

  ### Root Cause

  1. In readermenu.lua, KOReader loads the PageTurns menu table using dofile("frontend/ui/elements/page_turns.lua") inside
  ReaderMenu:setUpdateItemTable().
  2. dofile re-evaluates page_turns.lua from disk and creates a fresh table every time the menu is rendered.
  3. Therefore, calling table.insert(require("ui/elements/page_turns").sub_item_table, ...) only modified a cached Lua module table in package.loaded,
  which was overwritten and ignored when ReaderMenu ran dofile.

### Fix

  The patch now hooks ReaderMenu.init and uses self:registerToMainMenu(...) with an addToMainMenu handler:
```lua
    local ReaderMenu = require("apps/reader/modules/readermenu")
    local orig_ReaderMenu_init = ReaderMenu.init

    ReaderMenu.init = function(self)
        orig_ReaderMenu_init(self)
        self:registerToMainMenu({
            addToMainMenu = function(this, menu_items)
                if menu_items.page_turns and menu_items.page_turns.sub_item_table then
                    table.insert(menu_items.page_turns.sub_item_table, {
                        text = _("Software page turn animation"),
                        sub_item_table = { ... },
                    })
                end
            end,
        })
    end
```

### Captures

<img width="539" height="467" alt="image" src="https://github.com/user-attachments/assets/576693ea-812b-4b1c-b6a2-7650f72515a0" />
<img width="536" height="188" alt="image" src="https://github.com/user-attachments/assets/ac0dd18e-b124-44c5-aa23-d34062654995" />


